### PR TITLE
Update index.js for option noProcessValue

### DIFF
--- a/index.js
+++ b/index.js
@@ -408,7 +408,11 @@ function parse (args, opts) {
       addNewAlias(key, alias)
     }
 
-    var value = processValue(key, val)
+    //var value = processValue(key, val)
+    var value = val
+    if (configuration.noProcessValue===undefined
+      || !configuration.noProcessValue)
+      value =processValue(key, val)    
 
     var splitKey = key.split('.')
     setKey(argv, splitKey, value)


### PR DESCRIPTION
Sometimes a command line value not processed by `processValue` is required.
E.g., cannot distinguish between `value` and `"value"` but they could both be valid and carry different meanings for the application.
Initially hoped to modify yargs-parser and yargs so that both values (processed and unprocessed) could be recovered, but the singleton design and interface increase the workload by a large factor compared to this simple edit.